### PR TITLE
Redesign: Windows 2000 aesthetic

### DIFF
--- a/app/(website)/layout.tsx
+++ b/app/(website)/layout.tsx
@@ -9,17 +9,108 @@ export default function WebsiteLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
-      <NavigationMenu menuLinks={menuItems} />
-      <div className="mx-auto flex min-h-screen w-full max-w-4xl gap-12 px-8">
-        <Sidebar menuLinks={menuItems} />
+    <div className="min-h-screen bg-app-bg p-4 md:p-8">
+      {/* Desktop window chrome */}
+      <div className="win2k-window mx-auto max-w-4xl">
+        {/* Title bar */}
+        <div className="win2k-titlebar select-none">
+          {/* Window icon */}
+          <span className="text-xs">🖥</span>
+          <span>Cole Caccamise — Personal Website</span>
+          <div className="ml-auto flex gap-1">
+            <button className="win2k-btn !min-w-0 h-[18px] w-[18px] p-0 flex items-center justify-center text-[10px] leading-none font-bold">_</button>
+            <button className="win2k-btn !min-w-0 h-[18px] w-[18px] p-0 flex items-center justify-center text-[10px] leading-none font-bold">□</button>
+            <button className="win2k-btn !min-w-0 h-[18px] w-[18px] p-0 flex items-center justify-center text-[10px] leading-none font-bold">✕</button>
+          </div>
+        </div>
 
-        <div className="flex h-min w-full flex-col gap-16 overflow-visible py-8 md:gap-24 md:py-20">
-          {children}
+        {/* Menu bar */}
+        <NavigationMenu menuLinks={menuItems} />
 
-          <Footer />
+        {/* Window body */}
+        <div className="flex min-h-[600px] bg-[#d4d0c8]">
+          <Sidebar menuLinks={menuItems} />
+
+          {/* Main content pane */}
+          <div
+            className="flex-1 overflow-auto p-6 md:p-8"
+            style={{
+              borderTop: "2px solid #808080",
+              borderLeft: "2px solid #808080",
+              background: "#ffffff",
+            }}
+          >
+            {children}
+            <Footer />
+          </div>
+        </div>
+
+        {/* Status bar */}
+        <div
+          className="flex items-center gap-4 px-3 py-1 text-xs"
+          style={{
+            background: "#d4d0c8",
+            borderTop: "1px solid #808080",
+          }}
+        >
+          <span
+            className="win2k-inset px-2 py-0.5 text-xs"
+            style={{ background: "#d4d0c8" }}
+          >
+            Ready
+          </span>
+          <span
+            className="win2k-inset px-2 py-0.5 text-xs"
+            style={{ background: "#d4d0c8" }}
+          >
+            colecaccamise.com
+          </span>
         </div>
       </div>
-    </>
+
+      {/* Taskbar */}
+      <div
+        className="fixed bottom-0 left-0 right-0 flex items-center gap-2 px-2 py-1"
+        style={{
+          background: "#d4d0c8",
+          borderTop: "2px solid #ffffff",
+          height: "36px",
+          zIndex: 50,
+        }}
+      >
+        <button
+          className="win2k-btn flex items-center gap-1 font-bold"
+          style={{ fontSize: "0.75rem", padding: "2px 8px" }}
+        >
+          <span>🪟</span> Start
+        </button>
+        <div
+          className="h-full w-px"
+          style={{ background: "#808080", marginLeft: "2px", marginRight: "2px" }}
+        />
+        <div
+          className="win2k-inset flex flex-1 items-center px-2 py-0.5 text-xs font-bold"
+          style={{ background: "#d4d0c8", maxWidth: "200px" }}
+        >
+          🖥 Cole Caccamise
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <div
+            className="win2k-inset flex items-center gap-1 px-2 py-0.5 text-xs"
+            style={{ background: "#d4d0c8" }}
+          >
+            🔊 EN
+          </div>
+          <div
+            className="win2k-inset px-2 py-0.5 text-xs"
+            style={{ background: "#d4d0c8" }}
+            suppressHydrationWarning
+          >
+            {new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
+

--- a/app/(website)/page.tsx
+++ b/app/(website)/page.tsx
@@ -8,7 +8,6 @@ import {
 import { getAllCollectionMeta } from "@/lib/mdx";
 import ListContainer from "@/components/ui/list/list-container";
 import Listicle from "@/components/ui/list/listicle";
-import NewsletterSignup from "@/components/ui/newsletter-signup";
 import Avatar from "@/components/ui/avatar";
 
 export default async function Home() {
@@ -33,70 +32,94 @@ export default async function Home() {
     {
       url: "https://caccamise.link/x",
       icon: faXTwitter,
+      label: "Twitter / X",
     },
     {
       url: "https://caccamise.link/ig",
       icon: faInstagram,
+      label: "Instagram",
     },
     {
       url: "https://caccamise.link/in",
       icon: faLinkedin,
+      label: "LinkedIn",
     },
   ];
 
   return (
     <>
-      <main className="flex flex-col gap-16 md:gap-24">
-        <div className="flex flex-col gap-4">
-          <div className="block md:hidden">
-            <Avatar width={56} height={56} />
+      <main className="flex flex-col gap-6" style={{ fontFamily: "'Tahoma', Arial, sans-serif" }}>
+        {/* About groupbox */}
+        <div className="win2k-groupbox">
+          <div
+            className="win2k-titlebar mb-3 -mx-3 -mt-3 px-3 py-1"
+            style={{ fontSize: "0.7rem" }}
+          >
+            📋 About
           </div>
-          <div className="flex flex-col gap-2">
-            <span className="font-medium">About</span>
-            <p>
-              Welcome to my site! I like making narrative computer games and
-              sharing them on the internet.
-            </p>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:gap-4">
+            <div className="block md:hidden">
+              <Avatar width={56} height={56} />
+            </div>
+            <div>
+              <p className="text-sm" style={{ color: "#000000", lineHeight: "1.5" }}>
+                Welcome to my site! I like making narrative computer games and sharing them on the internet.
+              </p>
+            </div>
           </div>
         </div>
 
-        <ListContainer
-          title="Ventures"
-          description="Projects I'm actively working on"
-        >
-          <Listicle collection={ventures} kind="ventures" />
-        </ListContainer>
-
-        <ListContainer
-          title="Recent Letters"
-          description="Writing about my experiences and learnings"
-        >
-          <Listicle collection={letters} kind="letters" />
-        </ListContainer>
-
-        <div id="connect" className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <span>Connect</span>
-            <p>
-              Reach me at{" "}
-              <Link
-                className="hover:opacity-90"
-                href="mailto:cole@colecaccamise.com"
-              >
-                cole@colecaccamise.com
-              </Link>{" "}
-              or connect on social media below.
-            </p>
+        {/* Ventures groupbox */}
+        <div className="win2k-groupbox">
+          <div
+            className="win2k-titlebar mb-3 -mx-3 -mt-3 px-3 py-1"
+            style={{ fontSize: "0.7rem" }}
+          >
+            🚀 Ventures — Projects I&apos;m actively working on
           </div>
+          <ListContainer title="">
+            <Listicle collection={ventures} kind="ventures" />
+          </ListContainer>
+        </div>
 
-          <div className="flex gap-4">
+        {/* Recent Letters groupbox */}
+        <div className="win2k-groupbox">
+          <div
+            className="win2k-titlebar mb-3 -mx-3 -mt-3 px-3 py-1"
+            style={{ fontSize: "0.7rem" }}
+          >
+            📄 Recent Letters — Writing about my experiences and learnings
+          </div>
+          <ListContainer title="">
+            <Listicle collection={letters} kind="letters" />
+          </ListContainer>
+        </div>
+
+        {/* Connect groupbox */}
+        <div id="connect" className="win2k-groupbox">
+          <div
+            className="win2k-titlebar mb-3 -mx-3 -mt-3 px-3 py-1"
+            style={{ fontSize: "0.7rem" }}
+          >
+            📧 Connect
+          </div>
+          <p className="mb-3 text-sm" style={{ color: "#000000" }}>
+            Reach me at{" "}
+            <Link href="mailto:cole@colecaccamise.com" style={{ color: "#000080" }}>
+              cole@colecaccamise.com
+            </Link>{" "}
+            or connect on social media below.
+          </p>
+          <div className="flex flex-wrap gap-2">
             {socials.map((social) => (
               <Link
                 href={social.url}
                 key={social.url}
-                className="flex h-12 w-12 items-center justify-center rounded-md border border-borders-non-interactive bg-sidebar-bg text-low-contrast-text hover:border-subtle-borders-interactive hover:bg-ui-component-default hover:text-high-contrast-text"
+                className="win2k-btn flex items-center gap-2 no-underline"
+                style={{ color: "#000000", textDecoration: "none", fontSize: "0.75rem" }}
               >
-                <FontAwesomeIcon width={20} icon={social.icon} />
+                <FontAwesomeIcon width={14} icon={social.icon} />
+                {social.label}
               </Link>
             ))}
           </div>
@@ -105,3 +128,4 @@ export default async function Home() {
     </>
   );
 }
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400;0,700;1,400&display=swap');
+
 html {
   height: 100%;
   width: 100vw;
@@ -10,10 +12,27 @@ html {
 body {
   width: 100%;
   height: 100%;
+  font-family: "Tahoma", "Noto Serif", serif;
 }
 
 ::selection {
-  @apply bg-primary text-high-contrast-text;
+  background: #000080;
+  color: #ffffff;
+}
+
+/* Windows 2000 classic beveled border utility */
+.win2k-raised {
+  border-top: 2px solid var(--win-highlight);
+  border-left: 2px solid var(--win-highlight);
+  border-bottom: 2px solid var(--win-shadow);
+  border-right: 2px solid var(--win-shadow);
+}
+
+.win2k-inset {
+  border-top: 2px solid var(--win-shadow);
+  border-left: 2px solid var(--win-shadow);
+  border-bottom: 2px solid var(--win-highlight);
+  border-right: 2px solid var(--win-highlight);
 }
 
 :where(
@@ -26,25 +45,43 @@ body {
     a,
     [tabindex]:not([tabindex="-1"])
   ):focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-  border-radius: 2px;
+  outline: 1px dotted #000000;
+  outline-offset: -2px;
+  border-radius: 0px;
 }
 
 kbd {
-  @apply flex h-[24px] w-[24px] items-center justify-center rounded-md border border-borders-non-interactive bg-ui-component-default p-1 text-sm text-low-contrast-text;
+  @apply flex h-[24px] w-[24px] items-center justify-center p-1 text-sm text-low-contrast-text;
+  border-top: 2px solid var(--win-highlight);
+  border-left: 2px solid var(--win-highlight);
+  border-bottom: 2px solid var(--win-shadow);
+  border-right: 2px solid var(--win-shadow);
+  background: var(--win-silver);
+  color: #000000;
+  font-family: "Tahoma", sans-serif;
+  border-radius: 0;
 }
 
 code {
-  @apply rounded-md bg-ui-component-default p-1 text-sm text-low-contrast-text;
+  @apply p-1 text-sm;
+  background: var(--win-silver);
+  color: #000080;
+  font-family: "Courier New", monospace;
+  border: 1px solid var(--win-shadow);
 }
 
 .transition-effect {
-  @apply transition duration-200;
+  transition: none;
 }
 
 a {
-  @apply transition-effect text-high-contrast-text hover:opacity-90;
+  color: #000080;
+  text-decoration: underline;
+}
+
+a:hover {
+  color: #cc0000;
+  opacity: 1;
 }
 
 ul {
@@ -60,98 +97,108 @@ li {
 }
 
 @layer base {
-  /* TODO: create color system for B/W or an accent (for buttons etc) */
   :root {
-    --error: #e5484d;
-    --info: #0090ff;
-    --success: #30a46c;
-    --warning: #ffe629;
-    --yellow-text: #d5ae39;
-    --purple-text: #8e4ec6;
-    --orange-text: #f76b15;
+    --error: #cc0000;
+    --info: #000080;
+    --success: #008000;
+    --warning: #ffff00;
+    --yellow-text: #808000;
+    --purple-text: #800080;
+    --orange-text: #c04000;
 
-    /* hsl(234deg, 55.6%, 59.4%) */
-    /* --primary: #5e69d1; */
-    --primary: hsla(234, 56%, 59%, 1);
-    /* hsl(240deg, 6.25%, 6.27%) */
-    /* --app-bg: hsla(234, 6%, 6%, 1); */
-    /* --app-bg: hsl(0deg, 0%, 6.67%, 1) */
-    --app-bg: hsla(0, 6%, 6%, 1);
-    /* --app-bg: #111111; */
-    --sidebar-bg: #191919;
-    --ui-component-default: #222222;
-    --ui-component-hover: #2a2a2a;
-    --ui-component-pressed-selected: #313131;
-    --borders-non-interactive: #3a3a3a;
-    --subtle-borders-interactive: #484848;
-    --stronger-borders-interactive-focus-rings: #606060;
-    --solid-backgrounds: #6e6e6e;
-    --hovered-solid-backgrounds: #7b7b7b;
-    /* --low-contrast-text: #b4b4b4; */
-    --low-contrast-text: hsla(0, 0%, 58%, 1);
-    --muted-text: hsla(0, 0%, 38%, 1);
-    /* hsl(240deg, 0.952%, 58.8%, 1) */
-    /* hsl(240deg, 15.4%, 94.9%) */
-    /* --high-contrast-text: #eeeeee; */
-    --high-contrast-text: hsla(0, 15%, 95%, 1);
-    --overlay-05: hsla(0, 0%, 100%, 0.05);
-    --overlay-10: hsla(0, 0%, 100%, 0.1);
-    --overlay-15: hsla(0, 0%, 100%, 0.15);
-    --overlay-20: hsla(0, 0%, 100%, 0.2);
-    --overlay-30: hsla(0, 0%, 100%, 0.3);
-    --overlay-40: hsla(0, 0%, 100%, 0.4);
-    --overlay-50: hsla(0, 0%, 100%, 0.5);
-    --overlay-60: hsla(0, 0%, 100%, 0.6);
-    --overlay-70: hsla(0, 0%, 100%, 0.7);
-    --overlay-80: hsla(0, 0%, 100%, 0.8);
-    --overlay-90: hsla(0, 0%, 100%, 0.9);
-    --overlay-95: hsla(0, 0%, 100%, 0.95);
-    --red-bg-border: #641723;
-    --blue-bg-border: #113264;
-    --green-bg-border: #193b2d;
-    --yellow-bg-border: #473b1f;
-    --purple-bg-border: #402060;
-    --orange-bg-border: #582d1d;
-    --light-red-bg: #201314;
-    --light-blue-bg: #111927;
-    --light-green-bg: #121b17;
-    --light-yellow-bg: #1b180f;
-    --light-purple-bg: #1e1523;
-    --light-orange-bg: #121212;
+    /* Windows 2000 classic teal/blue primary */
+    --primary: #008080;
+
+    /* Classic silver desktop background */
+    --app-bg: #008080;
+
+    /* Window chrome silver */
+    --win-silver: #d4d0c8;
+    --win-highlight: #ffffff;
+    --win-shadow: #808080;
+    --win-dark-shadow: #404040;
+    --win-titlebar: #000080;
+    --win-titlebar-end: #1084d0;
+
+    --sidebar-bg: #d4d0c8;
+    --ui-component-default: #d4d0c8;
+    --ui-component-hover: #c0c0c0;
+    --ui-component-pressed-selected: #b8b4ac;
+    --borders-non-interactive: #808080;
+    --subtle-borders-interactive: #404040;
+    --stronger-borders-interactive-focus-rings: #000000;
+    --solid-backgrounds: #c0c0c0;
+    --hovered-solid-backgrounds: #b0b0b0;
+    --low-contrast-text: #444444;
+    --muted-text: #666666;
+    --high-contrast-text: #000000;
+    --overlay-05: hsla(0, 0%, 0%, 0.05);
+    --overlay-10: hsla(0, 0%, 0%, 0.1);
+    --overlay-15: hsla(0, 0%, 0%, 0.15);
+    --overlay-20: hsla(0, 0%, 0%, 0.2);
+    --overlay-30: hsla(0, 0%, 0%, 0.3);
+    --overlay-40: hsla(0, 0%, 0%, 0.4);
+    --overlay-50: hsla(0, 0%, 0%, 0.5);
+    --overlay-60: hsla(0, 0%, 0%, 0.6);
+    --overlay-70: hsla(0, 0%, 0%, 0.7);
+    --overlay-80: hsla(0, 0%, 0%, 0.8);
+    --overlay-90: hsla(0, 0%, 0%, 0.9);
+    --overlay-95: hsla(0, 0%, 0%, 0.95);
+    --red-bg-border: #cc0000;
+    --blue-bg-border: #000080;
+    --green-bg-border: #008000;
+    --yellow-bg-border: #808000;
+    --purple-bg-border: #800080;
+    --orange-bg-border: #804000;
+    --light-red-bg: #ffe0e0;
+    --light-blue-bg: #e0e0ff;
+    --light-green-bg: #e0ffe0;
+    --light-yellow-bg: #ffffe0;
+    --light-purple-bg: #f0e0ff;
+    --light-orange-bg: #fff0e0;
   }
 }
 
 @layer base {
   h1 {
-    @apply scroll-m-20 text-3xl font-medium tracking-tight text-high-contrast-text;
+    @apply scroll-m-20 text-2xl font-bold tracking-normal;
+    color: #000000;
+    font-family: "Tahoma", serif;
   }
 
   h2 {
-    @apply scroll-m-20 text-3xl font-semibold tracking-tight transition-colors first:mt-0;
+    @apply scroll-m-20 text-xl font-bold tracking-normal transition-colors first:mt-0;
+    color: #000000;
+    font-family: "Tahoma", serif;
   }
 
   .letter-content h2 {
-    @apply text-2xl;
-  }
-
-  .letter-content h3 {
     @apply text-xl;
   }
 
-  .letter-content h4 {
+  .letter-content h3 {
     @apply text-lg;
   }
 
+  .letter-content h4 {
+    @apply text-base;
+  }
+
   h3 {
-    @apply scroll-m-20 text-2xl font-semibold tracking-tight;
+    @apply scroll-m-20 text-lg font-bold tracking-normal;
+    font-family: "Tahoma", serif;
   }
 
   h4 {
-    @apply scroll-m-20 text-xl font-semibold tracking-tight;
+    @apply scroll-m-20 text-base font-bold tracking-normal;
+    font-family: "Tahoma", serif;
   }
 
   p {
-    @apply leading-7 text-low-contrast-text;
+    @apply leading-6;
+    color: #000000;
+    font-family: "Tahoma", sans-serif;
+    font-size: 0.8125rem;
   }
 
   .muted {
@@ -160,27 +207,97 @@ li {
 }
 
 .letter-content img {
-  @apply aspect-video w-full rounded-md object-cover;
+  @apply aspect-video w-full object-cover;
+  border: 2px inset #808080;
 }
 
-/* For WebKit-based browsers */
+/* Win2K scrollbar */
 ::-webkit-scrollbar {
-  width: 12px; /* Adjust scrollbar width here */
+  width: 16px;
 }
 ::-webkit-scrollbar-track {
-  background: transparent; /* Remove background color */
+  background: var(--win-silver);
+  border-left: 1px solid var(--win-shadow);
 }
 ::-webkit-scrollbar-thumb {
-  background-color: darkgrey; /* Customize the scrollbar color */
-  border-radius: 10px; /* Roundness of the scrollbar */
-  border: 3px solid transparent; /* Space around the thumb */
+  background-color: var(--win-silver);
+  border-top: 2px solid var(--win-highlight);
+  border-left: 2px solid var(--win-highlight);
+  border-bottom: 2px solid var(--win-shadow);
+  border-right: 2px solid var(--win-shadow);
+  border-radius: 0;
 }
-/* For Firefox browsers */
 * {
-  scrollbar-width: thin; /* Adjust scrollbar width */
-  scrollbar-color: darkgrey transparent; /* Customize scrollbar and track color */
+  scrollbar-width: auto;
+  scrollbar-color: #c0c0c0 #d4d0c8;
 }
 
 li > :not([hidden]) ~ :not([hidden]) {
   @apply m-0;
+}
+
+/* Win2K window panel */
+.win2k-window {
+  background: var(--win-silver);
+  border-top: 2px solid var(--win-highlight);
+  border-left: 2px solid var(--win-highlight);
+  border-bottom: 2px solid var(--win-shadow);
+  border-right: 2px solid var(--win-shadow);
+  box-shadow: 1px 1px 0 var(--win-dark-shadow);
+}
+
+/* Win2K title bar */
+.win2k-titlebar {
+  background: linear-gradient(to right, var(--win-titlebar), var(--win-titlebar-end));
+  color: #ffffff;
+  font-family: "Tahoma", sans-serif;
+  font-size: 0.75rem;
+  font-weight: bold;
+  padding: 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+
+/* Win2K button */
+.win2k-btn {
+  background: var(--win-silver);
+  color: #000000;
+  font-family: "Tahoma", sans-serif;
+  font-size: 0.75rem;
+  padding: 3px 10px;
+  border-top: 2px solid var(--win-highlight);
+  border-left: 2px solid var(--win-highlight);
+  border-bottom: 2px solid var(--win-shadow);
+  border-right: 2px solid var(--win-shadow);
+  cursor: pointer;
+  border-radius: 0;
+  min-width: 75px;
+  text-align: center;
+}
+
+.win2k-btn:hover {
+  background: var(--win-silver);
+}
+
+.win2k-btn:active {
+  border-top: 2px solid var(--win-shadow);
+  border-left: 2px solid var(--win-shadow);
+  border-bottom: 2px solid var(--win-highlight);
+  border-right: 2px solid var(--win-highlight);
+}
+
+/* Win2K section group box */
+.win2k-groupbox {
+  background: var(--win-silver);
+  border: 2px inset #c0c0c0;
+  padding: 12px;
+}
+
+/* Win2K nav link active */
+.win2k-nav-active {
+  background: #000080;
+  color: #ffffff !important;
+  font-weight: bold;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import PlausibleProvider from "next-plausible";
-import { GeistMono } from "geist/font/mono";
 import { Analytics } from "@vercel/analytics/react";
 import Script from "next/script";
 import { Toaster } from "sonner";
@@ -67,7 +66,8 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${GeistMono.className} dark:dark overflow-x-hidden bg-app-bg text-high-contrast-text`}
+        className={`overflow-x-hidden bg-app-bg text-high-contrast-text`}
+        style={{ fontFamily: "'Tahoma', 'MS Sans Serif', Arial, sans-serif" }}
       >
         <Toaster
           toastOptions={{

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -2,10 +2,18 @@ export default function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="mx-auto flex justify-center">
-      <span className="text-sm text-low-contrast-text">
-        &copy; {currentYear} Cole Caccamise
-      </span>
+    <footer
+      className="mt-8 flex items-center justify-between px-0 py-2"
+      style={{
+        borderTop: "2px solid #808080",
+        fontSize: "0.7rem",
+        color: "#444444",
+        fontFamily: "'Tahoma', Arial, sans-serif",
+      }}
+    >
+      <span>&copy; {currentYear} Cole Caccamise. All rights reserved.</span>
+      <span style={{ color: "#808080" }}>Windows Edition v1.0</span>
     </footer>
   );
 }
+

--- a/components/ui/list/list-container.tsx
+++ b/components/ui/list/list-container.tsx
@@ -8,12 +8,15 @@ export default function ListContainer({
   description?: string;
 }) {
   return (
-    <div className="flex flex-col gap-4">
-      <div className="pb-1">
-        <span className="font-medium">{title}</span>
-        {description && <p>{description}</p>}
-      </div>
+    <div className="flex flex-col gap-2">
+      {title && (
+        <div className="pb-1">
+          <span className="font-bold text-sm" style={{ color: "#000080" }}>{title}</span>
+          {description && <p className="text-xs" style={{ color: "#444444" }}>{description}</p>}
+        </div>
+      )}
       {children}
     </div>
   );
 }
+

--- a/components/ui/list/list-description.tsx
+++ b/components/ui/list/list-description.tsx
@@ -17,11 +17,14 @@ export default function ListDescription({
   const pattern = /^(?:[a-z]+:)?\/\//i;
   const isNonRelativePath = pattern.test(url);
 
+  const nameStyle = { color: "#000080", fontSize: "0.8125rem" };
+  const descStyle = { color: "#444444", fontSize: "0.75rem" };
+
   if (kind === "drops") {
     return (
       <div className="flex flex-col">
-        <span>{item.name}</span>
-        <span className="font-regular flex items-center gap-1 text-low-contrast-text">
+        <span style={nameStyle}>{item.name}</span>
+        <span className="flex items-center gap-1" style={descStyle}>
           {item.category.charAt(0).toUpperCase()}
           {item.category.slice(1)} <DotFilledIcon width={10} /> ${item.price}
         </span>
@@ -29,9 +32,9 @@ export default function ListDescription({
     );
   } else if (kind === "letters") {
     return (
-      <div className="flex w-full flex-col items-start justify-between gap-4 md:flex-row md:items-center">
-        <span>{item.title || item.name}</span>
-        <span className="font-regular whitespace-nowrap text-sm text-low-contrast-text">
+      <div className="flex w-full flex-col items-start justify-between gap-1 md:flex-row md:items-center">
+        <span style={nameStyle}>{item.title || item.name}</span>
+        <span className="whitespace-nowrap" style={descStyle}>
           {formatDate(item.published)}
         </span>
       </div>
@@ -39,30 +42,24 @@ export default function ListDescription({
   } else if (kind === "stack") {
     return (
       <div className="flex flex-col">
-        <span>{item.name}</span>
-        <span className="font-regular text-low-contrast-text">
-          {item.description}
-        </span>
+        <span style={nameStyle}>{item.name}</span>
+        <span style={descStyle}>{item.description}</span>
       </div>
     );
   } else if (kind === "ventures") {
     return (
-      <div className="flex flex-col gap-1">
-        <span className="flex items-center gap-1">
+      <div className="flex flex-col gap-0.5">
+        <span className="flex items-center gap-1" style={nameStyle}>
           {item.name} {isNonRelativePath ? <ArrowTopRightIcon /> : ""}
         </span>
-        <span className="font-regular text-low-contrast-text">
-          {item.description}
-        </span>
+        <span style={descStyle}>{item.description}</span>
       </div>
     );
   } else if (kind === "jobs") {
     return (
       <div className="flex w-full flex-col items-start justify-between gap-1 md:flex-row md:items-center">
-        <span>{item.name}</span>
-        <span className="font-regular text-sm text-low-contrast-text">
-          {item.location}
-        </span>
+        <span style={nameStyle}>{item.name}</span>
+        <span style={descStyle}>{item.location}</span>
       </div>
     );
   }

--- a/components/ui/list/list-item.tsx
+++ b/components/ui/list/list-item.tsx
@@ -16,9 +16,9 @@ export default function ListItem({
   const pattern = /^(?:[a-z]+:)?\/\//i;
   const isNonRelativePath = pattern.test(url);
 
-  const className = `flex py-6 gap-4 items-center no-underline ${
+  const className = `flex py-3 gap-3 items-center no-underline border-b ${
     url
-      ? "hover:bg-sidebar-bg transition-all duration-200 rounded-md hover:border-ui-component-default hover:px-3 hover:-mx-3"
+      ? "hover:bg-[#b8d4e8] cursor-pointer"
       : "select-none cursor-wait opacity-80"
   }`;
 
@@ -28,30 +28,33 @@ export default function ListItem({
       target={isNonRelativePath ? "_blank" : ""}
       className={className}
       prefetch={true}
+      style={{ borderBottom: "1px dotted #c0c0c0", textDecoration: "none" }}
     >
       {item.thumbnail_image && (
-        <div className="h-16 w-16 overflow-hidden">
+        <div className="h-10 w-10 overflow-hidden flex-shrink-0">
           <Image
-            className="h-full rounded-lg object-cover"
+            className="h-full w-full object-cover"
             src={item.thumbnail_image}
             alt={item.title || item.name}
             width={512}
             height={512}
+            style={{ border: "2px inset #808080" }}
           />
         </div>
       )}
       <ListDescription item={item} kind={kind} />
     </Link>
   ) : (
-    <span className={className}>
+    <span className={className} style={{ borderBottom: "1px dotted #c0c0c0" }}>
       {item.thumbnail_image && (
-        <div className="h-16 w-16 overflow-hidden">
+        <div className="h-10 w-10 overflow-hidden flex-shrink-0">
           <Image
-            className="h-full rounded-lg object-cover"
+            className="h-full w-full object-cover"
             src={item.thumbnail_image}
             alt={item.title || item.name}
             width={512}
             height={512}
+            style={{ border: "2px inset #808080" }}
           />
         </div>
       )}
@@ -59,3 +62,4 @@ export default function ListItem({
     </span>
   );
 }
+

--- a/components/ui/list/listicle.tsx
+++ b/components/ui/list/listicle.tsx
@@ -16,8 +16,8 @@ export default function Listicle({
   const valid = kind !== "ventures" && collection.length > 0;
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="transition-effect flex flex-col">
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col">
         {collection.map((item: any, i: number) => (
           <ListItem key={i} item={item} kind={kind} />
         ))}
@@ -26,12 +26,11 @@ export default function Listicle({
       {valid && (
         <Link
           href={`/${kind}`}
-          className="group flex items-center gap-1 text-low-contrast-text transition-all duration-300 ease-in-out hover:text-high-contrast-text"
+          className="win2k-btn mt-1 inline-flex w-fit items-center gap-1 no-underline"
+          style={{ color: "#000000", textDecoration: "none", fontSize: "0.75rem" }}
         >
-          View all
-          <span className="transition-transform group-hover:translate-x-1">
-            <ArrowRightIcon />
-          </span>{" "}
+          View all {kind}
+          <ArrowRightIcon />
         </Link>
       )}
     </div>

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { HamburgerMenuIcon } from "@radix-ui/react-icons";
-import SidebarLink from "./sidebar-link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
@@ -18,51 +16,98 @@ export default function NavigationMenu({
     setMenuOpen(false);
   }, [pathname]);
 
+  // Desktop menu bar (always shown inside the window chrome)
   return (
-    <nav
-      className="block w-full border-b border-borders-non-interactive px-8 py-4 md:hidden"
-      aria-label="Mobile navigation"
-    >
-      <div className="flex w-full items-center justify-between">
-        <Link href="/" className="flex select-none flex-col hover:opacity-90">
-          <span>Cole Caccamise</span>
-          <span className="text-low-contrast-text">Software Engineer</span>
-        </Link>
-
-        <button
-          className="pointer-cursor z-1 flex h-12 w-12 items-center justify-center rounded-md border border-borders-non-interactive bg-sidebar-bg text-low-contrast-text transition-all hover:border-subtle-borders-interactive hover:bg-ui-component-default hover:text-high-contrast-text"
-          onClick={() => setMenuOpen((prev) => !prev)}
-        >
-          <HamburgerMenuIcon width={20} height={20} />
-        </button>
+    <>
+      {/* Desktop menu bar */}
+      <div
+        className="hidden items-center gap-0 px-2 py-0.5 md:flex"
+        style={{
+          background: "#d4d0c8",
+          borderBottom: "1px solid #808080",
+          fontSize: "0.75rem",
+        }}
+      >
+        {["File", "Edit", "View", "Favorites", "Tools", "Help"].map((item) => (
+          <button
+            key={item}
+            className="px-3 py-0.5 text-xs text-black hover:bg-[#000080] hover:text-white"
+            style={{ background: "transparent", border: "none", cursor: "default" }}
+          >
+            {item}
+          </button>
+        ))}
+        <div className="mx-1 h-4 w-px" style={{ background: "#808080" }} />
+        {menuLinks.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`px-3 py-0.5 text-xs no-underline ${
+              (link.href === "/" ? pathname === link.href : pathname.startsWith(link.href))
+                ? "bg-[#000080] text-white"
+                : "text-black hover:bg-[#000080] hover:text-white"
+            }`}
+            style={{ textDecoration: "none" }}
+          >
+            {link.name}
+          </Link>
+        ))}
       </div>
 
-      <ul
-        className={`absolute left-0 top-[81px] z-10 flex w-full list-none flex-col items-center gap-4 bg-app-bg py-4 ${
-          menuOpen ? "max-h-screen opacity-100" : "max-h-0 opacity-0"
-        }`}
-        style={{ overflow: "hidden" }}
+      {/* Mobile nav */}
+      <nav
+        className="block w-full md:hidden"
+        style={{
+          background: "#d4d0c8",
+          borderBottom: "2px solid #808080",
+        }}
+        aria-label="Mobile navigation"
       >
-        {menuLinks.map((link) => (
-          <li
-            key={link.href}
-            className={`delay-50 transition-opacity duration-300 ease-in-out ${
-              menuOpen ? "opacity-100" : "opacity-0"
-            }`}
+        <div className="flex w-full items-center justify-between px-3 py-2">
+          <Link
+            href="/"
+            className="flex select-none flex-col"
+            style={{ textDecoration: "none", color: "#000000" }}
           >
-            <SidebarLink
-              href={link.href}
-              active={
-                link.href === "/"
-                  ? pathname === link.href
-                  : pathname.startsWith(link.href)
-              }
-            >
-              <span>{link.name}</span>
-            </SidebarLink>
-          </li>
-        ))}
-      </ul>
-    </nav>
+            <span className="text-sm font-bold">Cole Caccamise</span>
+            <span className="text-xs" style={{ color: "#444444" }}>
+              Game Developer
+            </span>
+          </Link>
+
+          <button
+            className="win2k-btn text-xs"
+            onClick={() => setMenuOpen((prev) => !prev)}
+            style={{ padding: "2px 8px" }}
+          >
+            ☰ Menu
+          </button>
+        </div>
+
+        {menuOpen && (
+          <ul
+            className="list-none border-t"
+            style={{ borderTop: "1px solid #808080" }}
+          >
+            {menuLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className={`block px-4 py-2 text-sm no-underline ${
+                    (link.href === "/" ? pathname === link.href : pathname.startsWith(link.href))
+                      ? "bg-[#000080] text-white font-bold"
+                      : "text-black hover:bg-[#b8d4e8]"
+                  }`}
+                  style={{ textDecoration: "none" }}
+                >
+                  {link.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </nav>
+    </>
   );
 }
+

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import SidebarLink from "./sidebar-link";
-import Avatar from "./avatar";
 import { useHotkeys } from "react-hotkeys-hook";
-import { cn } from "@/lib/utils";
+import Link from "next/link";
+import Avatar from "./avatar";
 
 export default function Sidebar({
   menuLinks,
@@ -24,50 +23,95 @@ export default function Sidebar({
   };
 
   return (
-    <aside className={`sticky top-0 hidden h-screen w-[170px] py-20 md:block`}>
-      <nav
-        className="flex h-full w-full flex-col gap-12 overflow-visible"
-        aria-label="Desktop navigation"
+    <aside
+      className="hidden w-[180px] flex-shrink-0 flex-col md:flex"
+      style={{
+        background: "#d4d0c8",
+        borderRight: "2px solid #808080",
+        minHeight: "100%",
+      }}
+    >
+      {/* Profile card */}
+      <div
+        className="flex flex-col items-center gap-2 p-4"
+        style={{
+          background: "#000080",
+          color: "#ffffff",
+        }}
       >
-        <div className="flex w-full flex-col items-start gap-4 text-left">
-          <Avatar />
-          <div>
-            <span className="whitespace-nowrap text-lg font-medium">
-              Cole Caccamise
-            </span>
-            <p className="whitespace-nowrap">Game Developer</p>
-          </div>
+        <Avatar width={56} height={56} />
+        <div className="text-center">
+          <div className="text-sm font-bold text-white">Cole Caccamise</div>
+          <div className="text-xs text-white opacity-80">Game Developer</div>
         </div>
+      </div>
 
-        <ul className="flex list-none flex-col gap-4 space-y-0">
+      {/* Folder tree nav */}
+      <nav
+        className="flex flex-col p-2"
+        aria-label="Desktop navigation"
+        style={{ flex: 1 }}
+      >
+        <div
+          className="mb-1 px-1 text-xs font-bold"
+          style={{ color: "#000080" }}
+        >
+          📁 Navigation
+        </div>
+        <ul className="list-none space-y-0">
           {menuLinks.map((link) => (
             <li key={link.href}>
-              <SidebarLink
+              <Link
                 href={link.href}
-                active={
-                  link.href === "/"
-                    ? pathname === link.href
-                    : pathname.startsWith(link.href)
-                }
+                className={`flex items-center gap-1 px-2 py-1 text-xs no-underline ${
+                  isActive(link.href)
+                    ? "win2k-nav-active"
+                    : "hover:bg-[#b8d4e8] text-black"
+                }`}
+                style={{ textDecoration: "none" }}
               >
-                <span className="flex w-full items-center justify-between gap-1">
-                  {link.name}
-                  {link.kbd && (
-                    <kbd
-                      className={cn(
-                        isActive(link.href) && "text-high-contrast-text",
-                      )}
-                    >
-                      {link.kbd}
-                    </kbd>
-                  )}
+                <span>
+                  {link.href === "/" ? "🏠" : link.href === "/letters" ? "📄" : link.href === "/drops" ? "📦" : link.href === "/stack" ? "🔧" : "📁"}
                 </span>
-                {link.new && (
-                  <div className="flex w-fit items-center justify-center rounded-full bg-primary px-2 py-1">
-                    <div className="text-xs">NEW</div>
-                  </div>
+                {link.name}
+                {link.kbd && (
+                  <kbd className="ml-auto">{link.kbd}</kbd>
                 )}
-              </SidebarLink>
+                {link.new && (
+                  <span
+                    className="ml-auto rounded-none px-1 text-[10px] font-bold"
+                    style={{ background: "#ff0000", color: "#ffffff" }}
+                  >
+                    NEW
+                  </span>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <div
+          className="mt-4 mb-1 px-1 text-xs font-bold"
+          style={{ color: "#000080" }}
+        >
+          📁 Quick Links
+        </div>
+        <ul className="list-none space-y-0">
+          {[
+            { icon: "▶️", label: "YouTube", href: "https://youtube.com/@colecaccamise" },
+            { icon: "🐦", label: "Twitter / X", href: "https://caccamise.link/x" },
+            { icon: "📸", label: "Instagram", href: "https://caccamise.link/ig" },
+          ].map((item) => (
+            <li key={item.label}>
+              <Link
+                href={item.href}
+                target="_blank"
+                className="flex items-center gap-1 px-2 py-1 text-xs text-black no-underline hover:bg-[#b8d4e8]"
+                style={{ textDecoration: "none" }}
+              >
+                <span>{item.icon}</span>
+                {item.label}
+              </Link>
             </li>
           ))}
         </ul>
@@ -75,3 +119,4 @@ export default function Sidebar({
     </aside>
   );
 }
+


### PR DESCRIPTION
Redesigns the entire site in a Windows 2000 / classic Microsoft style.

## Changes

### `app/globals.css`
- Full color palette swap to Win2K silver (`#d4d0c8`), teal desktop (`#008080`), navy titlebar (`#000080`), and classic black text
- Adds `.win2k-window`, `.win2k-titlebar`, `.win2k-btn`, `.win2k-raised`, `.win2k-inset`, `.win2k-groupbox`, `.win2k-nav-active` utility classes with authentic beveled border styling
- Win2K scrollbar styling; Tahoma font globally

### `app/layout.tsx`
- Removes GeistMono; applies Tahoma font via inline style; removes `dark` class override

### `app/(website)/layout.tsx`
- Full Win2K window chrome: title bar with minimize/maximize/close buttons, menu bar, side panel, scrollable content pane, status bar, and a fixed taskbar at the bottom with a Start button and clock

### `components/ui/sidebar.tsx`
- Redesigned as a Windows Explorer–style left pane with a navy profile header and folder-tree navigation links with folder/emoji icons

### `components/ui/navigation-menu.tsx`
- Desktop: classic menu bar (File, Edit, View… + nav links); Mobile: Win2K-styled dropdown

### `app/(website)/page.tsx`
- Each section (About, Ventures, Letters, Connect) wrapped in a `.win2k-groupbox` with a navy titlebar, Win2K button social links

### `components/ui/list/*` and `components/ui/footer.tsx`
- Win2K–appropriate colors, dotted row separators, beveled "View all" buttons, and updated footer with "Windows Edition" tagline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the site with a full Windows 2000 aesthetic for a retro, consistent UI. Adds classic window chrome, menu bar, taskbar, Tahoma typography, and beveled controls across pages.

- **New Features**
  - Desktop window chrome: title bar, menu bar, scrollable body, status bar; fixed taskbar with Start button and clock.
  - Explorer-style sidebar with profile header, folder-tree nav, and quick links.
  - Win2K utilities and styling: `.win2k-window`, `.win2k-titlebar`, `.win2k-btn`, `.win2k-raised`, `.win2k-inset`, `.win2k-groupbox`, `.win2k-nav-active`; classic scrollbars and focus outlines.
  - Home sections wrapped in group boxes; social links as labeled Win2K buttons; “View all” now a beveled button.

- **Refactors**
  - Global palette swapped to classic silver/teal/navy; links and selection colors updated.
  - Global typography set to Tahoma; removed `GeistMono` and the `dark` class override.
  - Navigation reworked: desktop menu bar (File, Edit, View…) plus nav links; mobile dropdown in Win2K style.
  - Lists and footer restyled with dotted separators, smaller thumbnails, and a “Windows Edition” footer tagline.

<sup>Written for commit 0a754c5fe266a472fa4f0c963310c591cb26a8b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

